### PR TITLE
Instantiate link builder before core template stuff.

### DIFF
--- a/files/includes/auto_loaders/config.ceon_uri_mapping.php
+++ b/files/includes/auto_loaders/config.ceon_uri_mapping.php
@@ -33,7 +33,7 @@ $autoLoadConfig[0][] = array(
     'autoType' => 'class',
     'loadFile' => 'observers/class.ceon_uri_mapping_link_build.php'
      );
-$autoLoadConfig[165][] = array(
+$autoLoadConfig[99][] = array(
     'autoType' => 'classInstantiate',
     'className' => 'CeonUriMappingLinkBuild',
     'objectName' => 'ceon_uri_mapping_link_build'


### PR DESCRIPTION
Core file init_templates.php may bring in language files that use link building, e.g. FOOTER_TEXT_BODY may contain links to EZ pages via zen_href_link(). Ceon observer must be registered before these language strings are evaluated.

Originally I proposed breakpoint 100 but looking at `config.core.php` I see that at 100 `template_func` is instantiated.  At present its constructor doesn't do anything significant but that may change.  So, I've made this PR set the breakpoint to 99 to sneak in just before any of those core template things are acted on.